### PR TITLE
fix: a cube constraint shall constrain its observations

### DIFF
--- a/validation/standalone-constraint-constraint.ttl
+++ b/validation/standalone-constraint-constraint.ttl
@@ -18,6 +18,12 @@
     a sh:NodeShape ;
     sh:targetClass cube:Constraint ;
     sh:property [
+        # a cube constraint shall constrain its observations
+        sh:path sh:targetClass ;
+        sh:hasValue cube:Observation;
+        sh:message "cube:Constraint needs a sh:targetClass cube:Observation"
+    ] ;
+    sh:property [
         # we assume at least 3 dimensions, otherwise we would have an empty list of dimensions
         # one for cube:observedBy, one for rdf:type and at least one cube dimension
         sh:path sh:property ;


### PR DESCRIPTION
@ktk a cube constraint shall constrain its observations 

according to the cube specs in https://cube.link/#observationConstraint

cc @kronmar @tpluscode @BenjaminHofstetter @claudiodigallo