### PR TITLE
fix: adjust base URL of shapes

### DIFF
--- a/.changeset/kind-geese-lie.md
+++ b/.changeset/kind-geese-lie.md
@@ -1,0 +1,5 @@
+---
+"cube-link": minor
+---
+
+Adjust shape base to match how they are deployed (re #94)

--- a/validation/basic-cube-constraint-ml.ttl
+++ b/validation/basic-cube-constraint-ml.ttl
@@ -1,4 +1,4 @@
-@base <http://example.org/> .
+@base <https://cube.link/shape/basic-cube-constraint-ml#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -46,7 +46,7 @@
         sh:path sh:property ;
         sh:minCount 3 ;
         sh:message "cube:Constraint needs at least a certain amount of sh:properties"
-    ] , 
+    ] ,
     [
         # we assume at least 3 dimensions, otherwise we would have an empty list of dimensions
         # one for cube:observedBy, one for rdf:type and at least one cube dimension

--- a/validation/basic-cube-constraint.ttl
+++ b/validation/basic-cube-constraint.ttl
@@ -1,4 +1,4 @@
-@base <http://example.org/> .
+@base <https://cube.link/shape/basic-cube-constraint#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/validation/datacatalog-constraint.ttl
+++ b/validation/datacatalog-constraint.ttl
@@ -1,4 +1,4 @@
-@base <http://example.org/> .
+@base <https://cube.link/shape/datacatalog-constraint#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -114,33 +114,33 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
         sh:minCount 1 ;
         sh:nodeKind sh:IRI ;
         sh:message "schema:Dataset needs a schema:hasPart"
-    ] ;    
+    ] ;
     sh:property [
         sh:path void:sparqlEndpoint ;
         sh:minCount 1 ;
         sh:nodeKind sh:IRI ;
         sh:message "schema:Dataset needs a void:sparqlEndpoint"
-    ] ; 
+    ] ;
     sh:property [
         sh:path void:rootResource ;
         sh:minCount 1 ;
         sh:nodeKind sh:IRI ;
         sh:message "schema:Dataset needs a void:rootResource"
-    ] ; 
+    ] ;
     sh:property [
         sh:path void:exampleResource ;
         sh:minCount 1 ;
         sh:nodeKind sh:IRI ;
         sh:message "schema:Dataset needs a void:exampleResource"
-    ] ; 
+    ] ;
     sh:property [
         sh:path dcat:distribution ;
         sh:minCount 1 ;
         sh:nodeKind sh:IRI ;
         sh:node <DCATDistributionShape>;
         sh:message "schema:Dataset needs a valid dcat:Distribution"
-    ] ; 
-    
+    ] ;
+
     .
 
 <DCATDistributionShape>

--- a/validation/standalone-constraint-constraint.ttl
+++ b/validation/standalone-constraint-constraint.ttl
@@ -1,4 +1,4 @@
-@base <http://example.org/> .
+@base <https://cube.link/shape/standalone-constraint-constraint#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -73,7 +73,7 @@
         sh:node <DimensionRelation>;
         sh:message "meta:dimensionRelation does not validate"
     ];
-    
+
     sh:or(
         [
             sh:path schema:name;
@@ -138,7 +138,7 @@
 	    ]
 	) ;
     ]
-    .    
+    .
 
 <DimensionRelation> a sh:NodeShape ;
     sh:property [

--- a/validation/standalone-cube-constraint.ttl
+++ b/validation/standalone-cube-constraint.ttl
@@ -1,4 +1,4 @@
-@base <http://example.org/> .
+@base <https://cube.link/shape/standalone-cube-constraint#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -9,7 +9,7 @@
 
 #
 # This is the bare minimal SHACL shape for validating a cube.
-# All cubes should pass this validation. 
+# All cubes should pass this validation.
 # It does not validate the constraints
 #
 
@@ -82,7 +82,7 @@
         # optional, but recommended
         sh:path cube:observationConstraint ;
         sh:message "cube:Cube must point to a valid constraint"
-    ] 
+    ]
     .
 
 <ObservationSetShape>
@@ -104,4 +104,4 @@
         sh:minCount 1 ;
         sh:nodeKind sh:IRI ;
         sh:message "cube:Observation requires cube:observedBy"
-    ] .    
+    ] .


### PR DESCRIPTION
Since we're now serving these shapes from trifid, I remove the `example.org` from the sources. This may not be ideal, because the requests are always `/shape/{version}/...` and the version segment will be omitted in he response but it is good enough for SHACL engine which takes all shapes from whatever graph

I also bump minor so that we can do non-breaking changes on patch versions.