### PR TITLE
fix: observationConstraint vs. observationShape

### DIFF
--- a/.changeset/green-turkeys-give.md
+++ b/.changeset/green-turkeys-give.md
@@ -1,0 +1,5 @@
+---
+"cube-link": patch
+---
+
+Fixes the problem that validation script did not correctly target cube observations

--- a/validate.js
+++ b/validate.js
@@ -17,7 +17,7 @@ The cube and shape are connected on the fly with triples in the following patter
 _:b1 a sh:NodeShape;
   sh:targetNode ?cube;
   sh:property [
-    sh:node ?observationShape; # from ?cube cube:observationShape ?observationShape
+    sh:node ?observationShape; # from ?cube cube:observationConstraint ?observationShape
     sh:path (cube:observationSet cube:observation);
   ].
 
@@ -32,7 +32,7 @@ async function validateCube (cube, shape) {
   clownface({ dataset: shape, term: rdf.blankNode() })
     .addOut(ns.sh.targetNode, cubeRoot)
     .addOut(ns.sh.property, null, property => {
-      property.addOut(ns.sh.node, cubeRoot.out(ns.cube.observationShape))
+      property.addOut(ns.sh.node, cubeRoot.out(ns.cube.observationConstraint))
       property.addList(ns.sh.path, [ns.cube.observationSet, ns.cube.observation])
     })
 


### PR DESCRIPTION
code to link the constraint (as also suggested in https://github.com/zazuko/cube-link/pull/93#issuecomment-1731453201,) was already there but not working due to wrong naming