### PR TITLE
doc: additional constraint in example

### DIFF
--- a/documentation/core.md
+++ b/documentation/core.md
@@ -180,7 +180,7 @@ To provide a generic solution that works for all numbers and IRIs, _Cube Schema_
     sh:path ex:literalDimension;
     sh:nodeKind sh:Literal;
     sh:or([
-        sh:datatype xsd:string
+        sh:datatype xsd:string ; sh:minLength 1
     ], [
         sh:datatype cube:Undefined
     ])

--- a/documentation/core.md
+++ b/documentation/core.md
@@ -174,7 +174,7 @@ To provide a generic solution that works for all numbers and IRIs, _Cube Schema_
 <observation2> a cube:Observation;
   ex:literalDimension ""^^cube:Undefined.
 
-## Snippet for for the according shape:
+## Snippet for the according shape:
 
 [
     sh:path ex:literalDimension;
@@ -190,6 +190,8 @@ To provide a generic solution that works for all numbers and IRIs, _Cube Schema_
 </aside>
 
 If it is necessary to state why the value is `cube:Undefined`, annotations should be used.
+
+Additional constraints (like `sh:minLength` in the example) may be placed within the _real_ data type so that they do not apply to undefined values.
 
 
 ## Metadata


### PR DESCRIPTION
added a `sh:minLength` constraint in the `cube:Undefined` example to suggest that additional constraints should be placed inside the `sh:or` branch for the _real_ data type, so that they do not apply when the value is undefined.