### PR TITLE
feat: send shapes directly without redirect

### DIFF
--- a/.changeset/slimy-ravens-chew.md
+++ b/.changeset/slimy-ravens-chew.md
@@ -1,0 +1,5 @@
+---
+"cube-link": patch
+---
+
+Forward profiles directly from GitHub

--- a/trifid/redirect.js
+++ b/trifid/redirect.js
@@ -55,7 +55,7 @@ function factory () {
         }
       }
       if (shapePath) {
-        return fetch(`https://raw.githubusercdontent.com/zazuko/cube-link/${versionPath}/validation/${shapePath}.ttl`)
+        return fetch(`https://raw.githubusercontent.com/zazuko/cube-link/${versionPath}/validation/${shapePath}.ttl`)
           .then(rawGithub => {
             if (rawGithub.ok) {
               res.set('Content-Type', 'text/turtle')

--- a/trifid/redirect.js
+++ b/trifid/redirect.js
@@ -1,4 +1,5 @@
 // @ts-check
+const { Readable } = require('stream')
 const { fetchBuilder, MemoryCache } = require('node-fetch-cache')
 
 /**
@@ -54,7 +55,19 @@ function factory () {
         }
       }
       if (shapePath) {
-        return res.redirect(`https://raw.githubusercontent.com/zazuko/cube-link/${versionPath}/validation/${shapePath}.ttl`)
+        return fetch(`https://raw.githubusercdontent.com/zazuko/cube-link/${versionPath}/validation/${shapePath}.ttl`)
+          .then(rawGithub => {
+            if (rawGithub.ok) {
+              res.set('Content-Type', 'text/turtle')
+            } else {
+              res.status(500)
+            }
+            Readable.fromWeb(rawGithub.body).pipe(res)
+          })
+          .catch((e) => {
+            res.status(502)
+            res.send(`Error fetching shape: ${e.message}`)
+          })
       }
     }
 


### PR DESCRIPTION
The use of raw GitHub links is problematic, because they are served with content type `text/plain`.

I propose to get rid of redirect and instead forward the body from GitHub so that we can set the `text/turtle` media type as is should be