### PR TITLE
make standalone-constraint-constraint conform to shacl-shacl

### DIFF
--- a/test/standalone-constraint-constraint/invalid.withoutName.ttl.approved.txt
+++ b/test/standalone-constraint-constraint/invalid.withoutName.ttl.approved.txt
@@ -11,12 +11,11 @@ _:report a sh:ValidationReport ;
 		sh:sourceConstraintComponent sh:NodeConstraintComponent ;
 		sh:sourceShape [
 			sh:path sh:property ;
-			sh:node <https://cube.link/shape/PropertyPath>, <https://cube.link/shape/PropertyWithName>, <https://cube.link/shape/PropertyNameType>, <https://cube.link/shape/PropertyWithType>, <https://cube.link/shape/PropertyScaleType>, <https://cube.link/shape/PropertyRange>, <https://cube.link/shape/PropertyInList>, <https://cube.link/shape/DimensionRelation> ;
-			sh:message "The constraints do not validate" ;
+			sh:node <https://cube.link/shape/PropertyWithName> ;
+			sh:message "needs a schema:name" ;
 		] ;
 		sh:focusNode <https://example.org/shape> ;
 		sh:value _:b3 ;
-		sh:resultMessage "The constraints do not validate" ;
 		sh:detail [
 			rdf:type sh:ValidationResult ;
 			sh:resultSeverity sh:Violation ;
@@ -24,8 +23,8 @@ _:report a sh:ValidationReport ;
 			sh:sourceShape <https://cube.link/shape/PropertyWithName> ;
 			sh:focusNode _:b3 ;
 			sh:value _:b3 ;
-			sh:resultMessage "needs a schema:name" ;
 		] ;
 		sh:resultPath sh:property ;
+		sh:resultMessage "needs a schema:name" ;
 	] ;
 	sh:conforms false .

--- a/test/standalone-constraint-constraint/invalid.withoutName.ttl.approved.txt
+++ b/test/standalone-constraint-constraint/invalid.withoutName.ttl.approved.txt
@@ -11,7 +11,7 @@ _:report a sh:ValidationReport ;
 		sh:sourceConstraintComponent sh:NodeConstraintComponent ;
 		sh:sourceShape [
 			sh:path sh:property ;
-			sh:node <https://cube.link/shape/ObservationConstraintProperty>, <https://cube.link/shape/PropertyWithName>, <https://cube.link/shape/PropertyWithType> ;
+			sh:node <https://cube.link/shape/PropertyPath>, <https://cube.link/shape/PropertyWithName>, <https://cube.link/shape/PropertyNameType>, <https://cube.link/shape/PropertyWithType>, <https://cube.link/shape/PropertyScaleType>, <https://cube.link/shape/PropertyRange>, <https://cube.link/shape/PropertyInList>, <https://cube.link/shape/DimensionRelation> ;
 			sh:message "The constraints do not validate" ;
 		] ;
 		sh:focusNode <https://example.org/shape> ;

--- a/test/standalone-constraint-constraint/invalid.withoutName.ttl.approved.txt
+++ b/test/standalone-constraint-constraint/invalid.withoutName.ttl.approved.txt
@@ -11,7 +11,7 @@ _:report a sh:ValidationReport ;
 		sh:sourceConstraintComponent sh:NodeConstraintComponent ;
 		sh:sourceShape [
 			sh:path sh:property ;
-			sh:node <https://cube.link/shape/ObservationConstraintProperty> ;
+			sh:node <https://cube.link/shape/ObservationConstraintProperty>, <https://cube.link/shape/PropertyWithName>, <https://cube.link/shape/PropertyWithType> ;
 			sh:message "The constraints do not validate" ;
 		] ;
 		sh:focusNode <https://example.org/shape> ;
@@ -21,30 +21,7 @@ _:report a sh:ValidationReport ;
 			rdf:type sh:ValidationResult ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:OrConstraintComponent ;
-			sh:sourceShape [
-				sh:message "needs a schema:name" ;
-				sh:or (
-					[
-						sh:path schema:name ;
-						sh:or (
-							[
-								sh:datatype xsd:string ;
-							]
-							[
-								sh:datatype rdf:langString ;
-							]
-						) ;
-						sh:minCount 1 ;
-					]
-					[
-						sh:path sh:path ;
-						sh:in (
-							rdf:type
-							cube:observedBy
-						) ;
-					]
-				) ;
-			] ;
+			sh:sourceShape <https://cube.link/shape/PropertyWithName> ;
 			sh:focusNode _:b3 ;
 			sh:value _:b3 ;
 			sh:resultMessage "needs a schema:name" ;

--- a/test/standalone-constraint-constraint/invalid.withoutType.ttl.approved.txt
+++ b/test/standalone-constraint-constraint/invalid.withoutType.ttl.approved.txt
@@ -11,7 +11,7 @@ _:report a sh:ValidationReport ;
 		sh:sourceConstraintComponent sh:NodeConstraintComponent ;
 		sh:sourceShape [
 			sh:path sh:property ;
-			sh:node <https://cube.link/shape/ObservationConstraintProperty>, <https://cube.link/shape/PropertyWithName>, <https://cube.link/shape/PropertyWithType> ;
+			sh:node <https://cube.link/shape/PropertyPath>, <https://cube.link/shape/PropertyWithName>, <https://cube.link/shape/PropertyNameType>, <https://cube.link/shape/PropertyWithType>, <https://cube.link/shape/PropertyScaleType>, <https://cube.link/shape/PropertyRange>, <https://cube.link/shape/PropertyInList>, <https://cube.link/shape/DimensionRelation> ;
 			sh:message "The constraints do not validate" ;
 		] ;
 		sh:focusNode <https://example.org/shape> ;

--- a/test/standalone-constraint-constraint/invalid.withoutType.ttl.approved.txt
+++ b/test/standalone-constraint-constraint/invalid.withoutType.ttl.approved.txt
@@ -11,12 +11,11 @@ _:report a sh:ValidationReport ;
 		sh:sourceConstraintComponent sh:NodeConstraintComponent ;
 		sh:sourceShape [
 			sh:path sh:property ;
-			sh:node <https://cube.link/shape/PropertyPath>, <https://cube.link/shape/PropertyWithName>, <https://cube.link/shape/PropertyNameType>, <https://cube.link/shape/PropertyWithType>, <https://cube.link/shape/PropertyScaleType>, <https://cube.link/shape/PropertyRange>, <https://cube.link/shape/PropertyInList>, <https://cube.link/shape/DimensionRelation> ;
-			sh:message "The constraints do not validate" ;
+			sh:node <https://cube.link/shape/PropertyWithType> ;
+			sh:message "needs a sh:datatype, sh:nodeKind or sh:datatype within sh:or (...)" ;
 		] ;
 		sh:focusNode <https://example.org/shape> ;
 		sh:value _:b3 ;
-		sh:resultMessage "The constraints do not validate" ;
 		sh:detail [
 			rdf:type sh:ValidationResult ;
 			sh:resultSeverity sh:Violation ;
@@ -24,8 +23,8 @@ _:report a sh:ValidationReport ;
 			sh:sourceShape <https://cube.link/shape/PropertyWithType> ;
 			sh:focusNode _:b3 ;
 			sh:value _:b3 ;
-			sh:resultMessage "needs a sh:datatype, sh:nodeKind or sh:datatype within sh:or (...)" ;
 		] ;
 		sh:resultPath sh:property ;
+		sh:resultMessage "needs a sh:datatype, sh:nodeKind or sh:datatype within sh:or (...)" ;
 	] ;
 	sh:conforms false .

--- a/test/standalone-constraint-constraint/invalid.withoutType.ttl.approved.txt
+++ b/test/standalone-constraint-constraint/invalid.withoutType.ttl.approved.txt
@@ -11,7 +11,7 @@ _:report a sh:ValidationReport ;
 		sh:sourceConstraintComponent sh:NodeConstraintComponent ;
 		sh:sourceShape [
 			sh:path sh:property ;
-			sh:node <https://cube.link/shape/ObservationConstraintProperty> ;
+			sh:node <https://cube.link/shape/ObservationConstraintProperty>, <https://cube.link/shape/PropertyWithName>, <https://cube.link/shape/PropertyWithType> ;
 			sh:message "The constraints do not validate" ;
 		] ;
 		sh:focusNode <https://example.org/shape> ;
@@ -21,35 +21,7 @@ _:report a sh:ValidationReport ;
 			rdf:type sh:ValidationResult ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:OrConstraintComponent ;
-			sh:sourceShape [
-				sh:message "needs a sh:datatype, sh:nodeKind or sh:datatype within sh:or (...)" ;
-				sh:or (
-					[
-						sh:path sh:datatype ;
-						sh:minCount 1 ;
-					]
-					[
-						sh:path sh:nodeKind ;
-						sh:minCount 1 ;
-					]
-					[
-						sh:path sh:or ;
-						sh:node <https://cube.link/shape/listnode>, [
-							sh:property [
-								sh:path sh:datatype ;
-								sh:minCount 1 ;
-							] ;
-							sh:path (
-								[
-									sh:zeroOrMorePath rdf:rest ;
-								]
-								rdf:first
-							) ;
-						] ;
-						sh:minCount 1 ;
-					]
-				) ;
-			] ;
+			sh:sourceShape <https://cube.link/shape/PropertyWithType> ;
 			sh:focusNode _:b3 ;
 			sh:value _:b3 ;
 			sh:resultMessage "needs a sh:datatype, sh:nodeKind or sh:datatype within sh:or (...)" ;

--- a/validation/standalone-constraint-constraint.ttl
+++ b/validation/standalone-constraint-constraint.ttl
@@ -26,8 +26,8 @@
     ] ;
     sh:property [
         sh:path sh:property ;
-        sh:node <ObservationConstraintProperty>;
-        sh:message "The constraints do not validate"
+        sh:node <ObservationConstraintProperty>, <PropertyWithName>, <PropertyWithType> ;
+        sh:message "The constraints do not validate";
     ] ;
 	sh:property [
         sh:path sh:closed;
@@ -39,6 +39,43 @@
         sh:message "meta:inHierarchy does not validate"
     ] ;
     .
+
+<PropertyWithName> a sh:NodeShape ;
+    sh:message "needs a schema:name" ;
+    sh:or(
+        [
+            sh:path schema:name;
+            sh:minCount 1;
+        ]
+        [
+            sh:path sh:path;
+            sh:in (rdf:type cube:observedBy);
+        ]
+    );
+.
+
+<PropertyWithType> a sh:NodeShape ;
+    sh:message "needs a sh:datatype, sh:nodeKind or sh:datatype within sh:or (...)" ;
+    sh:or(
+        [
+            sh:path sh:datatype;
+            sh:minCount 1;
+        ]
+        [
+            sh:path sh:nodeKind;
+            sh:minCount 1;
+        ]
+        [
+            sh:path sh:or;
+            sh:minCount 1;
+            sh:node <listnode> ;
+            sh:property [
+                sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ; # all list elements
+                sh:property [ sh:path sh:datatype ; sh:minCount 1 ] ; # have at least one datatype
+            ]
+        ]
+    );
+.
 
 <ObservationConstraintProperty> a sh:NodeShape;
 	sh:property [
@@ -73,44 +110,11 @@
         sh:node <DimensionRelation>;
         sh:message "meta:dimensionRelation does not validate"
     ];
-
     sh:property [
-        sh:message "needs a schema:name" ;
-        sh:or(
-            [
-                sh:path schema:name;
-                sh:minCount 1;
-                sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] ) ;
-            ]
-            [
-                sh:path sh:path;
-                sh:in (rdf:type cube:observedBy);
-            ]
-        );
+        sh:path schema:name;
+        sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] ) ;
+        sh:message "schema:name needs to be a xsd:string or a rdf:langString"
     ];
-
-    sh:property [
-        sh:message "needs a sh:datatype, sh:nodeKind or sh:datatype within sh:or (...)" ;
-        sh:or(
-            [
-                sh:path sh:datatype;
-                sh:minCount 1;
-            ]
-            [
-                sh:path sh:nodeKind;
-                sh:minCount 1;
-            ]
-            [
-                sh:path sh:or;
-                sh:minCount 1;
-                sh:node <listnode> ;
-                sh:node [
-                    sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ; # all list elements
-                    sh:property [ sh:path sh:datatype ; sh:minCount 1 ] ; # have at least one datatype
-                ]
-            ]
-        );
-    ] ;
 
 .
 

--- a/validation/standalone-constraint-constraint.ttl
+++ b/validation/standalone-constraint-constraint.ttl
@@ -24,19 +24,45 @@
         sh:minCount 3 ;
         sh:message "cube:Constraint needs at least a certain amount of sh:properties"
     ] ;
-    sh:property [
-        sh:path sh:property ;
-        sh:node
-            <PropertyPath> ,
-            <PropertyWithName> , 
-            <PropertyNameType> ,
-            <PropertyWithType> ,
-            <PropertyScaleType> ,
-            <PropertyRange> ,
-            <PropertyInList> ,
-            <DimensionRelation> ;
-        sh:message "The constraints do not validate";
-    ] ;
+    sh:property
+        [
+            sh:path sh:property ;
+            sh:node <PropertyPath> ;
+            sh:message "a sh:path is needed on a property" ;
+        ] ,
+        [
+            sh:path sh:property ;
+            sh:node <PropertyWithName> ;
+            sh:message "needs a schema:name" ;
+        ] ,
+        [
+            sh:path sh:property ;
+            sh:node <PropertyNameType> ;
+            sh:message "schema:name needs to be a xsd:string or a rdf:langString" ;
+        ] ,
+        [
+            sh:path sh:property ;
+            sh:node <PropertyWithType> ;
+            sh:message "needs a sh:datatype, sh:nodeKind or sh:datatype within sh:or (...)" ;
+        ] ,
+        [
+            sh:path sh:property ;
+            sh:node <PropertyScaleType> ;
+            sh:message "If qudt:scaleType is used it needs to be within ( qudt:IntervalScale qudt:NominalScale qudt:EnumerationScale qudt:RatioScale qudt:OrdinalScale )" ;
+        ] ,
+        [
+            sh:path sh:property ;
+            sh:node <PropertyRange> ;
+        ] ,
+        [
+            sh:path sh:property ;
+            sh:node <PropertyInList> ;
+            sh:message "sh:in needs to be a list" ;
+        ] ,
+        [
+            sh:path sh:property ;
+            sh:node <DimensionRelation> ;
+        ] ;
 	sh:property [
         sh:path sh:closed;
         sh:hasValue true;
@@ -49,7 +75,6 @@
     .
 
 <PropertyPath> a sh:NodeShape ;
-    sh:message "a sh:path is needed on a property" ;
 	sh:property [
         sh:path sh:path;
         sh:minCount 1;
@@ -58,7 +83,6 @@
 .
 
 <PropertyWithName> a sh:NodeShape ;
-    sh:message "needs a schema:name" ;
     sh:or(
         [
             sh:path schema:name;
@@ -72,7 +96,6 @@
 .
 
 <PropertyNameType> a sh:NodeShape ;
-    sh:message "schema:name needs to be a xsd:string or a rdf:langString" ;
     sh:property [
         sh:path schema:name;
         sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] ) ;
@@ -80,7 +103,6 @@
 .
 
 <PropertyWithType> a sh:NodeShape ;
-    sh:message "needs a sh:datatype, sh:nodeKind or sh:datatype within sh:or (...)" ;
     sh:or(
         [
             sh:path sh:datatype;
@@ -103,7 +125,6 @@
 .
 
 <PropertyInList> a sh:NodeShape ;
-    sh:message "sh:in needs to be a list" ;
     sh:property [
         sh:path sh:in;
         sh:node <listnode>;
@@ -111,7 +132,6 @@
 .
 
 <PropertyScaleType> a sh:NodeShape ;
-	sh:message "If qudt:scaleType is used it needs to be within ( qudt:IntervalScale qudt:NominalScale qudt:EnumerationScale qudt:RatioScale qudt:OrdinalScale )" ;
     sh:property [
         sh:path qudt:scaleType;
         sh:in (qudt:IntervalScale qudt:NominalScale qudt:EnumerationScale qudt:RatioScale qudt:OrdinalScale) ;
@@ -140,8 +160,8 @@
             sh:nodeKind sh:IRI ;
             sh:minCount 1;
             sh:message "meta:dimensionRelation requires at least one meta:relatesTo";
-        ] 
-    ] 
+        ]
+    ]
 .
 
 

--- a/validation/standalone-constraint-constraint.ttl
+++ b/validation/standalone-constraint-constraint.ttl
@@ -26,7 +26,15 @@
     ] ;
     sh:property [
         sh:path sh:property ;
-        sh:node <ObservationConstraintProperty>, <PropertyWithName>, <PropertyWithType> ;
+        sh:node
+            <PropertyPath> ,
+            <PropertyWithName> , 
+            <PropertyNameType> ,
+            <PropertyWithType> ,
+            <PropertyScaleType> ,
+            <PropertyRange> ,
+            <PropertyInList> ,
+            <DimensionRelation> ;
         sh:message "The constraints do not validate";
     ] ;
 	sh:property [
@@ -40,6 +48,15 @@
     ] ;
     .
 
+<PropertyPath> a sh:NodeShape ;
+    sh:message "a sh:path is needed on a property" ;
+	sh:property [
+        sh:path sh:path;
+        sh:minCount 1;
+        sh:maxCount 1;
+    ];
+.
+
 <PropertyWithName> a sh:NodeShape ;
     sh:message "needs a schema:name" ;
     sh:or(
@@ -52,6 +69,14 @@
             sh:in (rdf:type cube:observedBy);
         ]
     );
+.
+
+<PropertyNameType> a sh:NodeShape ;
+    sh:message "schema:name needs to be a xsd:string or a rdf:langString" ;
+    sh:property [
+        sh:path schema:name;
+        sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] ) ;
+    ];
 .
 
 <PropertyWithType> a sh:NodeShape ;
@@ -77,55 +102,47 @@
     );
 .
 
-<ObservationConstraintProperty> a sh:NodeShape;
-	sh:property [
+<PropertyInList> a sh:NodeShape ;
+    sh:message "sh:in needs to be a list" ;
+    sh:property [
+        sh:path sh:in;
+        sh:node <listnode>;
+    ];
+.
+
+<PropertyScaleType> a sh:NodeShape ;
+	sh:message "If qudt:scaleType is used it needs to be within ( qudt:IntervalScale qudt:NominalScale qudt:EnumerationScale qudt:RatioScale qudt:OrdinalScale )" ;
+    sh:property [
         sh:path qudt:scaleType;
-        sh:in ( qudt:IntervalScale qudt:NominalScale qudt:EnumerationScale qudt:RatioScale qudt:OrdinalScale) ;
+        sh:in (qudt:IntervalScale qudt:NominalScale qudt:EnumerationScale qudt:RatioScale qudt:OrdinalScale) ;
         sh:maxCount 1;
-	    sh:message "If qudt:scaleType is used it needs to be within ( qudt:IntervalScale qudt:NominalScale qudt:EnumerationScale qudt:RatioScale qudt:OrdinalScale )"
     ];
-	sh:property [
-        sh:path sh:path;
-        sh:minCount 1;
-        sh:maxCount 1;
-        sh:message "a sh:path is needed on a property"
-    ];
+.
+
+<PropertyRange> a sh:NodeShape ;
     sh:property [
         sh:path sh:minInclusive;
         sh:nodeType sh:Literal;
         sh:message "sh:minInclusive needs to be a literal"
     ];
     sh:property [
-        sh:path sh:in;
-        sh:node <listnode>;
-        sh:message "sh:in needs to be a list"
-    ];
-    sh:property [
         sh:path sh:maxInclusive;
         sh:nodeType sh:Literal;
         sh:message "sh:maxInclusive needs to be a literal"
     ];
-    sh:property [
-        sh:path meta:dimensionRelation;
-        sh:node <DimensionRelation>;
-        sh:message "meta:dimensionRelation does not validate"
-    ];
-    sh:property [
-        sh:path schema:name;
-        sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] ) ;
-        sh:message "schema:name needs to be a xsd:string or a rdf:langString"
-    ];
-
 .
-
 
 <DimensionRelation> a sh:NodeShape ;
     sh:property [
-        sh:path meta:relatesTo;
-        sh:nodeKind sh:IRI ;
-        sh:minCount 1;
-        sh:message "meta:dimensionRelation requires at least one meta:relatesTo";
-    ] .
+        sh:path meta:dimensionRelation;
+        sh:property [
+            sh:path meta:relatesTo;
+            sh:nodeKind sh:IRI ;
+            sh:minCount 1;
+            sh:message "meta:dimensionRelation requires at least one meta:relatesTo";
+        ] 
+    ] 
+.
 
 
 # Testing proper rdf:list construction


### PR DESCRIPTION
I noticed that two shapes in `standalone-constraint-constraint.ttl` do not conform to [shacl-shacl](https://www.w3.org/ns/shacl-shacl). It is about the `sh:path` property (need exactly one for property shapes, none for node shapes). 
They are accepted by our validator library (and behave as intended) but I think it's safer to have an equivalent, compliant version.