### PR TITLE
perf: alternative shape for lists

### DIFF
--- a/.changeset/friendly-pumas-melt.md
+++ b/.changeset/friendly-pumas-melt.md
@@ -1,0 +1,5 @@
+---
+"cube-link": patch
+---
+
+Validating RDF Lists should now work with long lists of any size

--- a/meta/meta.ttl
+++ b/meta/meta.ttl
@@ -5,7 +5,7 @@ PREFIX meta: <https://cube.link/meta/>
 PREFIX schema: <http://schema.org/>
 
 meta:dimensionRelation a rdfs:Property;
-    rdfs:subClassOf meta:relatesTo;
+    rdfs:subPropertyOf meta:relatesTo;
     rdfs:label "dimension relation";
     rdfs:comment "A meta:dimensionRelation property is used to express the relation of this dimension in related to other dimension, examples are Deviation and StandardError";
     .

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "node-fetch-cache": "^3.1.3",
         "rdf-ext": "^1.3.0",
         "rdf-utils-fs": "^2.1.0",
-        "rdf-validate-shacl": "^0.4.3",
+        "rdf-validate-shacl": "^0.5.4",
         "trifid": "^2.4.0"
       },
       "bin": {
@@ -3446,8 +3446,7 @@
     "node_modules/@rdfjs/environment": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/environment/-/environment-1.0.0.tgz",
-      "integrity": "sha512-+S5YjSvfoQR5r7YQCRCCVHvIEyrWia7FJv2gqM3s5EDfotoAQmFeBagApa9c/eQFi5EiNhmBECE5nB8LIxTaHg==",
-      "dev": true
+      "integrity": "sha512-+S5YjSvfoQR5r7YQCRCCVHvIEyrWia7FJv2gqM3s5EDfotoAQmFeBagApa9c/eQFi5EiNhmBECE5nB8LIxTaHg=="
     },
     "node_modules/@rdfjs/fetch": {
       "version": "3.1.1",
@@ -4446,15 +4445,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-2.0.0.tgz",
       "integrity": "sha512-z0K8AgLsJGTrh+dGkXNl/oT9vBdMei4xq1MIeGN360oimA81Q+ruQUKFCbYNRRZS03tVHPBzqXUal/DezFGPEA==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/to-ntriples": "^2.0.0"
       }
     },
     "node_modules/@rdfjs/term-set": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-1.1.0.tgz",
-      "integrity": "sha512-QQ4yzVe1Rvae/GN9SnOhweHNpaxQtnAjeOVciP/yJ0Gfxtbphy2tM56ZsRLV04Qq5qMcSclZIe6irYyEzx/UwQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-2.0.2.tgz",
+      "integrity": "sha512-XSP+G9Q+QxeRcmTvUyFzdPJtGHdYDWr166UARO8UPhG/thUY2aHw7Qx17KTwTV0auJDSzO43AoJ6v/WdjrJ6pg==",
       "dependencies": {
         "@rdfjs/to-ntriples": "^2.0.0"
       }
@@ -4500,15 +4498,6 @@
       "dev": true,
       "dependencies": {
         "@rdfjs/data-model": "^2.0.1"
-      }
-    },
-    "node_modules/@rdfjs/tree/node_modules/@rdfjs/term-set": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-2.0.2.tgz",
-      "integrity": "sha512-XSP+G9Q+QxeRcmTvUyFzdPJtGHdYDWr166UARO8UPhG/thUY2aHw7Qx17KTwTV0auJDSzO43AoJ6v/WdjrJ6pg==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/to-ntriples": "^2.0.0"
       }
     },
     "node_modules/@rdfjs/types": {
@@ -4642,7 +4631,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-4.2.0.tgz",
       "integrity": "sha512-vSl+/38M3GKUV2mJ5HXfCxLUkoI3baRrBgLZnCKQPQUsptxzQGRxxIKFVHIIC3Dv+VA6V21/XLPl5Hik+nyRQQ==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/data-model": "^2",
         "@rdfjs/namespace": "^2",
@@ -4655,7 +4643,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
       "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
-      "dev": true,
       "bin": {
         "rdfjs-data-model-test": "bin/test.js"
       }
@@ -4664,7 +4651,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.0.tgz",
       "integrity": "sha512-cBBvNrlSOah4z7u2vS74Lxng/ivELy6tNPjx+G/Ag14up8z5xmX8njn+U/mJ+nlcXO7nDGK4rgaAq7jtl9S3CQ==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/data-model": "^2.0.0"
       }
@@ -5182,7 +5168,6 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.10.tgz",
       "integrity": "sha512-xoVzEIOxcpyteEmzaj94MSBbrBFs+vqv05joMhzLEiPRwsBBDnhkdBCaaDxR1Tf7wOW0kB2R1IYe4C3vEBFPgA==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
@@ -5371,7 +5356,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@vocabulary/sh/-/sh-1.1.5.tgz",
       "integrity": "sha512-8R4uxHLpwmp6l6szZdCtfQx0wRy64OHuOsYTDfhCsbJ773Uv6nCM2bYBtjjirZHN+2m3uHQWgtWOdvuu1jwmOA==",
-      "dev": true,
       "peerDependencies": {
         "@rdfjs/types": "^1.0.0"
       }
@@ -5468,15 +5452,6 @@
       "dev": true,
       "dependencies": {
         "@rdfjs/data-model": "^2.0.1"
-      }
-    },
-    "node_modules/@zazuko/env/node_modules/@rdfjs/term-set": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-2.0.2.tgz",
-      "integrity": "sha512-XSP+G9Q+QxeRcmTvUyFzdPJtGHdYDWr166UARO8UPhG/thUY2aHw7Qx17KTwTV0auJDSzO43AoJ6v/WdjrJ6pg==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/to-ntriples": "^2.0.0"
       }
     },
     "node_modules/@zazuko/env/node_modules/clownface": {
@@ -5751,8 +5726,7 @@
     "node_modules/@zazuko/prefixes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@zazuko/prefixes/-/prefixes-2.1.0.tgz",
-      "integrity": "sha512-dm0/YBNzuwJUm8cXoF3Dn9DfQetnRDaOJ8NdlgLY645OaUddCzUAAYcanm+xZmEo1SWX+/Tp3jbScwCaN2b/aQ==",
-      "dev": true
+      "integrity": "sha512-dm0/YBNzuwJUm8cXoF3Dn9DfQetnRDaOJ8NdlgLY645OaUddCzUAAYcanm+xZmEo1SWX+/Tp3jbScwCaN2b/aQ=="
     },
     "node_modules/@zazuko/rdf-utils-fs": {
       "version": "3.3.1",
@@ -7395,42 +7369,6 @@
         "readable-stream": "3 - 4"
       }
     },
-    "node_modules/barnard59-shacl/node_modules/@rdfjs/data-model": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.2.tgz",
-      "integrity": "sha512-v5LRNkLRJazMCGU7VtEzhz5wKwz/IrOdJEKapCtd35HuFbQfeGpoJP6QOXGyFHhWwKmtG+UMlZzYFyNDVE1m6g==",
-      "dev": true,
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "node_modules/barnard59-shacl/node_modules/@rdfjs/dataset": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-2.0.2.tgz",
-      "integrity": "sha512-6YJx+5n5Uxzq9dd9I0GGcIo6eopZOPfcsAfxSGX5d+YBzDgVa1cbtEBFnaPyPKiQsOm4+Cr3nwypjpg02YKPlA==",
-      "dev": true,
-      "bin": {
-        "rdfjs-dataset-test": "bin/test.js"
-      }
-    },
-    "node_modules/barnard59-shacl/node_modules/@rdfjs/namespace": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.1.tgz",
-      "integrity": "sha512-U85NWVGnL3gWvOZ4eXwUcv3/bom7PAcutSBQqmVWvOaslPy+kDzAJCH1WYBLpdQd4yMmJ+bpJcDl9rcHtXeixg==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/data-model": "^2.0.1"
-      }
-    },
-    "node_modules/barnard59-shacl/node_modules/@rdfjs/term-set": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-2.0.2.tgz",
-      "integrity": "sha512-XSP+G9Q+QxeRcmTvUyFzdPJtGHdYDWr166UARO8UPhG/thUY2aHw7Qx17KTwTV0auJDSzO43AoJ6v/WdjrJ6pg==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/to-ntriples": "^2.0.0"
-      }
-    },
     "node_modules/barnard59-shacl/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -7455,17 +7393,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/barnard59-shacl/node_modules/clownface": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/clownface/-/clownface-2.0.2.tgz",
-      "integrity": "sha512-HjTYqVXiCrw4FmoAWF46aQ3c2OmdVLoqZrAGkowdWWUoBBIcBht55pOxkyvoVe2BsPE/HqMzfnu51JpgqM4KEg==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/data-model": "^2.0.1",
-        "@rdfjs/environment": "0 - 1",
-        "@rdfjs/namespace": "^2.0.0"
-      }
-    },
     "node_modules/barnard59-shacl/node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -7476,34 +7403,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/barnard59-shacl/node_modules/rdf-validate-datatype": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/rdf-validate-datatype/-/rdf-validate-datatype-0.2.1.tgz",
-      "integrity": "sha512-DpREnmoWDxC80KyslZeBPLQb3ztyeiOolT4uCl58tCju2KHJu4j5vonmVVdEJh2Mpad5UY57v6sSM/hfSTFGKQ==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/term-map": "^2.0.0",
-        "@tpluscode/rdf-ns-builders": "3 - 4"
-      }
-    },
-    "node_modules/barnard59-shacl/node_modules/rdf-validate-shacl": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/rdf-validate-shacl/-/rdf-validate-shacl-0.5.3.tgz",
-      "integrity": "sha512-w3RQF/NinQN6QGaBYSjevDZyaG+De2yMLNPcuzwLe7ZnstIAhQl6n2wfJLSk9RHjw+zGcf6goqRoEqI7Sdclsg==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/data-model": "^2",
-        "@rdfjs/dataset": "^2",
-        "@rdfjs/environment": "^1",
-        "@rdfjs/namespace": "^2.0.0",
-        "@rdfjs/term-set": "^2.0.1",
-        "@vocabulary/sh": "^1.0.1",
-        "clownface": "^2.0.0",
-        "debug": "^4.3.2",
-        "rdf-literal": "^1.3.0",
-        "rdf-validate-datatype": "^0.2.0"
       }
     },
     "node_modules/barnard59-shacl/node_modules/readable-stream": {
@@ -19584,38 +19483,63 @@
       }
     },
     "node_modules/rdf-validate-datatype": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/rdf-validate-datatype/-/rdf-validate-datatype-0.1.5.tgz",
-      "integrity": "sha512-gU+cD+AT1LpFwbemuEmTDjwLyFwJDiw21XHyIofKhFnEpXODjShBuxhgDGnZqW3qIEwu/vECjOecuD60e5ngiQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rdf-validate-datatype/-/rdf-validate-datatype-0.2.1.tgz",
+      "integrity": "sha512-DpREnmoWDxC80KyslZeBPLQb3ztyeiOolT4uCl58tCju2KHJu4j5vonmVVdEJh2Mpad5UY57v6sSM/hfSTFGKQ==",
       "dependencies": {
-        "@rdfjs/namespace": "^1.1.0",
-        "@rdfjs/to-ntriples": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.4"
+        "@rdfjs/term-map": "^2.0.0",
+        "@tpluscode/rdf-ns-builders": "3 - 4"
       }
     },
     "node_modules/rdf-validate-shacl": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/rdf-validate-shacl/-/rdf-validate-shacl-0.4.5.tgz",
-      "integrity": "sha512-tGYnssuPzmsPua1dju4hEtGkT1zouvwzVTNrFhNiqj2aZFO5pQ7lvLd9Cv9H9vKAlpIdC/x0zL6btxG3PCss0w==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/rdf-validate-shacl/-/rdf-validate-shacl-0.5.4.tgz",
+      "integrity": "sha512-0d395JxiT/EyWzjL8X1lC2gy5x3W0MuoKnfywFqwUsqo2Vn/zCicnaF+wyuHnwS3A0lMyWf6nThh/WF8JjmCjw==",
       "dependencies": {
-        "@rdfjs/dataset": "^1.1.1",
-        "@rdfjs/namespace": "^1.0.0",
-        "@rdfjs/term-set": "^1.1.0",
-        "clownface": "^1.4.0",
+        "@rdfjs/data-model": "^2",
+        "@rdfjs/dataset": "^2",
+        "@rdfjs/environment": "^1",
+        "@rdfjs/namespace": "^2.0.0",
+        "@rdfjs/term-set": "^2.0.1",
+        "@vocabulary/sh": "^1.0.1",
+        "clownface": "^2.0.0",
         "debug": "^4.3.2",
         "rdf-literal": "^1.3.0",
-        "rdf-validate-datatype": "^0.1.5"
+        "rdf-validate-datatype": "^0.2.0"
+      }
+    },
+    "node_modules/rdf-validate-shacl/node_modules/@rdfjs/data-model": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.2.tgz",
+      "integrity": "sha512-v5LRNkLRJazMCGU7VtEzhz5wKwz/IrOdJEKapCtd35HuFbQfeGpoJP6QOXGyFHhWwKmtG+UMlZzYFyNDVE1m6g==",
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
+      }
+    },
+    "node_modules/rdf-validate-shacl/node_modules/@rdfjs/dataset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-2.0.2.tgz",
+      "integrity": "sha512-6YJx+5n5Uxzq9dd9I0GGcIo6eopZOPfcsAfxSGX5d+YBzDgVa1cbtEBFnaPyPKiQsOm4+Cr3nwypjpg02YKPlA==",
+      "bin": {
+        "rdfjs-dataset-test": "bin/test.js"
+      }
+    },
+    "node_modules/rdf-validate-shacl/node_modules/@rdfjs/namespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.1.tgz",
+      "integrity": "sha512-U85NWVGnL3gWvOZ4eXwUcv3/bom7PAcutSBQqmVWvOaslPy+kDzAJCH1WYBLpdQd4yMmJ+bpJcDl9rcHtXeixg==",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.1"
       }
     },
     "node_modules/rdf-validate-shacl/node_modules/clownface": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/clownface/-/clownface-1.5.1.tgz",
-      "integrity": "sha512-Ko8N/UFsnhEGmPlyE1bUFhbRhVgDbxqlIjcqxtLysc4dWaY0A7iCdg3savhAxs7Lheb7FCygIyRh7ADYZWVIng==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/clownface/-/clownface-2.0.2.tgz",
+      "integrity": "sha512-HjTYqVXiCrw4FmoAWF46aQ3c2OmdVLoqZrAGkowdWWUoBBIcBht55pOxkyvoVe2BsPE/HqMzfnu51JpgqM4KEg==",
       "dependencies": {
-        "@rdfjs/data-model": "^1.1.0",
-        "@rdfjs/namespace": "^1.0.0"
+        "@rdfjs/data-model": "^2.0.1",
+        "@rdfjs/environment": "0 - 1",
+        "@rdfjs/namespace": "^2.0.0"
       }
     },
     "node_modules/rdfxml-streaming-parser": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node-fetch-cache": "^3.1.3",
     "rdf-ext": "^1.3.0",
     "rdf-utils-fs": "^2.1.0",
-    "rdf-validate-shacl": "^0.4.3",
+    "rdf-validate-shacl": "^0.5.4",
     "trifid": "^2.4.0"
   },
   "devDependencies": {

--- a/test/profile-visualize/invalid-datatype-langstring.ttl.approved.txt
+++ b/test/profile-visualize/invalid-datatype-langstring.ttl.approved.txt
@@ -16,38 +16,28 @@ _:report a sh:ValidationReport ;
 			sh:node <https://cube.link/shape/profile-opendataswiss-lindas#ObservationConstraintShape> ;
 		] ;
 		sh:focusNode <http://example.org/Cube> ;
+		sh:resultPath cube:observationConstraint ;
 		sh:value <observationConstraint> ;
 		sh:resultMessage "Value does not have shape <https://cube.link/shape/profile-opendataswiss-lindas#ObservationConstraintShape>" ;
 		sh:detail [
 			rdf:type sh:ValidationResult ;
 			sh:resultSeverity sh:Violation ;
-			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
-			sh:sourceShape [
-				sh:nodeKind sh:IRI ;
-			] ;
-			sh:focusNode _:b1 ;
-			sh:value _:b1 ;
-			sh:resultMessage "Value does not have node kind <http://www.w3.org/ns/shacl#IRI>" ;
-		], [
-			rdf:type sh:ValidationResult ;
-			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:OrConstraintComponent ;
 			sh:sourceShape _:b633 ;
 			sh:focusNode <observationConstraint> ;
+			sh:resultPath sh:property ;
 			sh:value _:b2 ;
 			sh:resultMessage "Dimension constraint must have exactly one datatype. It cannot be rdf:langString" ;
-			sh:resultPath sh:property ;
 		] ;
-		sh:resultPath cube:observationConstraint ;
 	], [
 		rdf:type sh:ValidationResult ;
 		sh:resultSeverity sh:Violation ;
 		sh:sourceConstraintComponent sh:OrConstraintComponent ;
 		sh:sourceShape _:b633 ;
 		sh:focusNode <observationConstraint> ;
+		sh:resultPath sh:property ;
 		sh:value _:b2 ;
 		sh:resultMessage "Dimension constraint must have exactly one datatype. It cannot be rdf:langString" ;
-		sh:resultPath sh:property ;
 	] ;
 	sh:conforms false .
 

--- a/test/profile-visualize/invalid-datatype-multiple.ttl.approved.txt
+++ b/test/profile-visualize/invalid-datatype-multiple.ttl.approved.txt
@@ -16,38 +16,28 @@ _:report a sh:ValidationReport ;
 			sh:node <https://cube.link/shape/profile-opendataswiss-lindas#ObservationConstraintShape> ;
 		] ;
 		sh:focusNode <http://example.org/Cube> ;
+		sh:resultPath cube:observationConstraint ;
 		sh:value <observationConstraint> ;
 		sh:resultMessage "Value does not have shape <https://cube.link/shape/profile-opendataswiss-lindas#ObservationConstraintShape>" ;
 		sh:detail [
 			rdf:type sh:ValidationResult ;
 			sh:resultSeverity sh:Violation ;
-			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
-			sh:sourceShape [
-				sh:nodeKind sh:IRI ;
-			] ;
-			sh:focusNode _:b1 ;
-			sh:value _:b1 ;
-			sh:resultMessage "Value does not have node kind <http://www.w3.org/ns/shacl#IRI>" ;
-		], [
-			rdf:type sh:ValidationResult ;
-			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:OrConstraintComponent ;
 			sh:sourceShape _:b633 ;
 			sh:focusNode <observationConstraint> ;
+			sh:resultPath sh:property ;
 			sh:value _:b2 ;
 			sh:resultMessage "Dimension constraint must have exactly one datatype. It cannot be rdf:langString" ;
-			sh:resultPath sh:property ;
 		] ;
-		sh:resultPath cube:observationConstraint ;
 	], [
 		rdf:type sh:ValidationResult ;
 		sh:resultSeverity sh:Violation ;
 		sh:sourceConstraintComponent sh:OrConstraintComponent ;
 		sh:sourceShape _:b633 ;
 		sh:focusNode <observationConstraint> ;
+		sh:resultPath sh:property ;
 		sh:value _:b2 ;
 		sh:resultMessage "Dimension constraint must have exactly one datatype. It cannot be rdf:langString" ;
-		sh:resultPath sh:property ;
 	] ;
 	sh:conforms false .
 

--- a/test/profile-visualize/invalid-scale-types.ttl.approved.txt
+++ b/test/profile-visualize/invalid-scale-types.ttl.approved.txt
@@ -16,56 +16,46 @@ _:report a sh:ValidationReport ;
 			sh:node <https://cube.link/shape/profile-opendataswiss-lindas#ObservationConstraintShape> ;
 		] ;
 		sh:focusNode <http://example.org/Cube> ;
+		sh:resultPath cube:observationConstraint ;
 		sh:value <observationConstraint> ;
 		sh:resultMessage "Value does not have shape <https://cube.link/shape/profile-opendataswiss-lindas#ObservationConstraintShape>" ;
 		sh:detail [
 			rdf:type sh:ValidationResult ;
 			sh:resultSeverity sh:Violation ;
-			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
-			sh:sourceShape [
-				sh:nodeKind sh:IRI ;
-			] ;
-			sh:focusNode _:b1 ;
-			sh:value _:b1 ;
-			sh:resultMessage "Value does not have node kind <http://www.w3.org/ns/shacl#IRI>" ;
-		], [
-			rdf:type sh:ValidationResult ;
-			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:OrConstraintComponent ;
 			sh:sourceShape _:b643 ;
 			sh:focusNode <observationConstraint> ;
+			sh:resultPath sh:property ;
 			sh:value _:b2 ;
 			sh:resultMessage "Cube must have exactly one scaleType: qudt:IntervalScale, qudt:NominalScale, qudt:RatioScale, or qudt:OrdinalScale" ;
-			sh:resultPath sh:property ;
 		], [
 			rdf:type sh:ValidationResult ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:OrConstraintComponent ;
 			sh:sourceShape _:b643 ;
 			sh:focusNode <observationConstraint> ;
+			sh:resultPath sh:property ;
 			sh:value _:b3 ;
 			sh:resultMessage "Cube must have exactly one scaleType: qudt:IntervalScale, qudt:NominalScale, qudt:RatioScale, or qudt:OrdinalScale" ;
-			sh:resultPath sh:property ;
 		] ;
-		sh:resultPath cube:observationConstraint ;
 	], [
 		rdf:type sh:ValidationResult ;
 		sh:resultSeverity sh:Violation ;
 		sh:sourceConstraintComponent sh:OrConstraintComponent ;
 		sh:sourceShape _:b643 ;
 		sh:focusNode <observationConstraint> ;
+		sh:resultPath sh:property ;
 		sh:value _:b2 ;
 		sh:resultMessage "Cube must have exactly one scaleType: qudt:IntervalScale, qudt:NominalScale, qudt:RatioScale, or qudt:OrdinalScale" ;
-		sh:resultPath sh:property ;
 	], [
 		rdf:type sh:ValidationResult ;
 		sh:resultSeverity sh:Violation ;
 		sh:sourceConstraintComponent sh:OrConstraintComponent ;
 		sh:sourceShape _:b643 ;
 		sh:focusNode <observationConstraint> ;
+		sh:resultPath sh:property ;
 		sh:value _:b3 ;
 		sh:resultMessage "Cube must have exactly one scaleType: qudt:IntervalScale, qudt:NominalScale, qudt:RatioScale, or qudt:OrdinalScale" ;
-		sh:resultPath sh:property ;
 	] ;
 	sh:conforms false .
 

--- a/test/standalone-constraint-constraint/invalid.malformedList.ttl
+++ b/test/standalone-constraint-constraint/invalid.malformedList.ttl
@@ -1,0 +1,48 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix cube: <https://cube.link/> .
+@prefix observation: <https://environment.ld.admin.ch/foen/nfi/observation/max_min_undefined> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix schema: <http://schema.org/> .
+@base <https://example.org/> .
+
+<cube> a cube:Cube ;
+    cube:observationConstraint <shape> ;
+    cube:observationSet <observationSet> .
+
+<observationSet> cube:observation <observation> .
+
+<observation> a cube:Observation ;
+    cube:observedBy <observer> ;
+    <dimension1> "one" .
+
+
+<shape> a cube:Constraint ;
+    sh:targetClass cube:Observation ;
+    sh:closed true ;
+    sh:property
+        [
+            sh:path rdf:type ;
+            sh:nodeKind sh:IRI ;
+            sh:minCount 1 ;
+            sh:maxCount 1 ;
+            sh:in [ a rdf:List ; rdf:first cube:Observation ; rdf:rest rdf:nil ] # well-formed list
+        ] ;
+    sh:property
+        [
+            sh:path cube:observedBy ; ;
+            sh:nodeKind sh:IRI ;
+            sh:minCount 1 ;
+            sh:maxCount 1 ;
+            sh:in [ rdf:first <observer> ; rdf:rest rdf:wrong ] # malformed list
+        ] ;
+    sh:property
+        [
+            sh:datatype xsd:string ;
+            sh:path <dimension1> ;
+            schema:name "dimension 1" ;
+            sh:minCount 1 ;
+            sh:maxCount 1 ;
+            sh:in [ rdf:first "one" ] # malformed list
+        ] ;
+.

--- a/test/standalone-constraint-constraint/invalid.malformedList.ttl.approved.txt
+++ b/test/standalone-constraint-constraint/invalid.malformedList.ttl.approved.txt
@@ -1,0 +1,103 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix cube: <https://cube.link/> .
+
+_:report a sh:ValidationReport ;
+	sh:result [
+		rdf:type sh:ValidationResult ;
+		sh:resultSeverity sh:Violation ;
+		sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+		sh:sourceShape _:b675 ;
+		sh:focusNode _:b6 ;
+		sh:resultPath rdf:rest ;
+		sh:resultMessage "list node needs exactly one rdf:rest" ;
+	], [
+		rdf:type sh:ValidationResult ;
+		sh:resultSeverity sh:Violation ;
+		sh:sourceConstraintComponent sh:OrConstraintComponent ;
+		sh:sourceShape <https://cube.link/shape/standalone-constraint-constraint#restvalue> ;
+		sh:focusNode rdf:wrong ;
+		sh:resultMessage "rdf:rest value must be a list node or rdf:nil" ;
+		sh:value rdf:wrong ;
+	], [
+		rdf:type sh:ValidationResult ;
+		sh:resultSeverity sh:Violation ;
+		sh:sourceConstraintComponent sh:NodeConstraintComponent ;
+		sh:sourceShape [
+			sh:path sh:property ;
+			sh:message "sh:in needs to be a list" ;
+			sh:node <https://cube.link/shape/standalone-constraint-constraint#PropertyInList> ;
+		] ;
+		sh:focusNode <https://example.org/shape> ;
+		sh:resultPath sh:property ;
+		sh:resultMessage "sh:in needs to be a list" ;
+		sh:value _:b5 ;
+		sh:detail [
+			rdf:type sh:ValidationResult ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:NodeConstraintComponent ;
+			sh:sourceShape [
+				sh:path sh:in ;
+				sh:node <https://cube.link/shape/standalone-constraint-constraint#listnode> ;
+			] ;
+			sh:focusNode _:b5 ;
+			sh:resultPath sh:in ;
+			sh:resultMessage "Value does not have shape <https://cube.link/shape/standalone-constraint-constraint#listnode>" ;
+			sh:value _:b6 ;
+			sh:detail [
+				rdf:type sh:ValidationResult ;
+				sh:resultSeverity sh:Violation ;
+				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+				sh:sourceShape _:b636 ;
+				sh:focusNode _:b1 ;
+				sh:resultPath schema:name ;
+				sh:resultMessage "Less than 1 values" ;
+			], [
+				rdf:type sh:ValidationResult ;
+				sh:resultSeverity sh:Violation ;
+				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+				sh:sourceShape _:b636 ;
+				sh:focusNode _:b3 ;
+				sh:resultPath schema:name ;
+				sh:resultMessage "Less than 1 values" ;
+			], [
+				rdf:type sh:ValidationResult ;
+				sh:resultSeverity sh:Violation ;
+				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+				sh:sourceShape _:b647 ;
+				sh:focusNode _:b1 ;
+				sh:resultPath sh:datatype ;
+				sh:resultMessage "Less than 1 values" ;
+			], [
+				rdf:type sh:ValidationResult ;
+				sh:resultSeverity sh:Violation ;
+				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+				sh:sourceShape _:b647 ;
+				sh:focusNode _:b3 ;
+				sh:resultPath sh:datatype ;
+				sh:resultMessage "Less than 1 values" ;
+			], [
+				rdf:type sh:ValidationResult ;
+				sh:resultSeverity sh:Violation ;
+				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+				sh:sourceShape _:b675 ;
+				sh:focusNode _:b6 ;
+				sh:resultPath rdf:rest ;
+				sh:resultMessage "list node needs exactly one rdf:rest" ;
+			] ;
+		] ;
+	] ;
+	sh:conforms false .
+
+_:b675 sh:path rdf:rest ;
+	sh:maxCount 1 ;
+	sh:minCount 1 ;
+	sh:message "list node needs exactly one rdf:rest" .
+
+_:b636 sh:path schema:name ;
+	sh:minCount 1 .
+
+_:b647 sh:path sh:datatype ;
+	sh:minCount 1 .

--- a/test/standalone-constraint-constraint/invalid.malformedList.ttl.approved.txt
+++ b/test/standalone-constraint-constraint/invalid.malformedList.ttl.approved.txt
@@ -9,7 +9,7 @@ _:report a sh:ValidationReport ;
 		rdf:type sh:ValidationResult ;
 		sh:resultSeverity sh:Violation ;
 		sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
-		sh:sourceShape _:b675 ;
+		sh:sourceShape _:b678 ;
 		sh:focusNode _:b6 ;
 		sh:resultPath rdf:rest ;
 		sh:resultMessage "list node needs exactly one rdf:rest" ;
@@ -40,7 +40,7 @@ _:report a sh:ValidationReport ;
 				rdf:type sh:ValidationResult ;
 				sh:resultSeverity sh:Violation ;
 				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
-				sh:sourceShape _:b636 ;
+				sh:sourceShape _:b639 ;
 				sh:focusNode _:b1 ;
 				sh:resultPath schema:name ;
 				sh:resultMessage "Less than 1 values" ;
@@ -48,7 +48,7 @@ _:report a sh:ValidationReport ;
 				rdf:type sh:ValidationResult ;
 				sh:resultSeverity sh:Violation ;
 				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
-				sh:sourceShape _:b636 ;
+				sh:sourceShape _:b639 ;
 				sh:focusNode _:b3 ;
 				sh:resultPath schema:name ;
 				sh:resultMessage "Less than 1 values" ;
@@ -56,7 +56,7 @@ _:report a sh:ValidationReport ;
 				rdf:type sh:ValidationResult ;
 				sh:resultSeverity sh:Violation ;
 				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
-				sh:sourceShape _:b647 ;
+				sh:sourceShape _:b650 ;
 				sh:focusNode _:b1 ;
 				sh:resultPath sh:datatype ;
 				sh:resultMessage "Less than 1 values" ;
@@ -64,7 +64,7 @@ _:report a sh:ValidationReport ;
 				rdf:type sh:ValidationResult ;
 				sh:resultSeverity sh:Violation ;
 				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
-				sh:sourceShape _:b647 ;
+				sh:sourceShape _:b650 ;
 				sh:focusNode _:b3 ;
 				sh:resultPath sh:datatype ;
 				sh:resultMessage "Less than 1 values" ;
@@ -72,7 +72,7 @@ _:report a sh:ValidationReport ;
 				rdf:type sh:ValidationResult ;
 				sh:resultSeverity sh:Violation ;
 				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
-				sh:sourceShape _:b675 ;
+				sh:sourceShape _:b678 ;
 				sh:focusNode _:b6 ;
 				sh:resultPath rdf:rest ;
 				sh:resultMessage "list node needs exactly one rdf:rest" ;
@@ -91,13 +91,13 @@ _:report a sh:ValidationReport ;
 	] ;
 	sh:conforms false .
 
-_:b675 sh:path rdf:rest ;
+_:b678 sh:path rdf:rest ;
 	sh:maxCount 1 ;
 	sh:minCount 1 ;
 	sh:message "list node needs exactly one rdf:rest" .
 
-_:b636 sh:path schema:name ;
+_:b639 sh:path schema:name ;
 	sh:minCount 1 .
 
-_:b647 sh:path sh:datatype ;
+_:b650 sh:path sh:datatype ;
 	sh:minCount 1 .

--- a/test/standalone-constraint-constraint/invalid.malformedList.ttl.approved.txt
+++ b/test/standalone-constraint-constraint/invalid.malformedList.ttl.approved.txt
@@ -16,14 +16,6 @@ _:report a sh:ValidationReport ;
 	], [
 		rdf:type sh:ValidationResult ;
 		sh:resultSeverity sh:Violation ;
-		sh:sourceConstraintComponent sh:OrConstraintComponent ;
-		sh:sourceShape <https://cube.link/shape/standalone-constraint-constraint#restvalue> ;
-		sh:focusNode rdf:wrong ;
-		sh:resultMessage "rdf:rest value must be a list node or rdf:nil" ;
-		sh:value rdf:wrong ;
-	], [
-		rdf:type sh:ValidationResult ;
-		sh:resultSeverity sh:Violation ;
 		sh:sourceConstraintComponent sh:NodeConstraintComponent ;
 		sh:sourceShape [
 			sh:path sh:property ;
@@ -33,7 +25,6 @@ _:report a sh:ValidationReport ;
 		sh:focusNode <https://example.org/shape> ;
 		sh:resultPath sh:property ;
 		sh:resultMessage "sh:in needs to be a list" ;
-		sh:value _:b5 ;
 		sh:detail [
 			rdf:type sh:ValidationResult ;
 			sh:resultSeverity sh:Violation ;
@@ -45,7 +36,6 @@ _:report a sh:ValidationReport ;
 			sh:focusNode _:b5 ;
 			sh:resultPath sh:in ;
 			sh:resultMessage "Value does not have shape <https://cube.link/shape/standalone-constraint-constraint#listnode>" ;
-			sh:value _:b6 ;
 			sh:detail [
 				rdf:type sh:ValidationResult ;
 				sh:resultSeverity sh:Violation ;
@@ -87,7 +77,17 @@ _:report a sh:ValidationReport ;
 				sh:resultPath rdf:rest ;
 				sh:resultMessage "list node needs exactly one rdf:rest" ;
 			] ;
+			sh:value _:b6 ;
 		] ;
+		sh:value _:b5 ;
+	], [
+		rdf:type sh:ValidationResult ;
+		sh:resultSeverity sh:Violation ;
+		sh:sourceConstraintComponent sh:XoneConstraintComponent ;
+		sh:sourceShape <https://cube.link/shape/standalone-constraint-constraint#restvalue> ;
+		sh:focusNode rdf:wrong ;
+		sh:resultMessage "rdf:rest value must be a list node or rdf:nil" ;
+		sh:value rdf:wrong ;
 	] ;
 	sh:conforms false .
 

--- a/test/standalone-constraint-constraint/invalid.malformedList.ttl.approved.txt
+++ b/test/standalone-constraint-constraint/invalid.malformedList.ttl.approved.txt
@@ -40,38 +40,6 @@ _:report a sh:ValidationReport ;
 				rdf:type sh:ValidationResult ;
 				sh:resultSeverity sh:Violation ;
 				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
-				sh:sourceShape _:b639 ;
-				sh:focusNode _:b1 ;
-				sh:resultPath schema:name ;
-				sh:resultMessage "Less than 1 values" ;
-			], [
-				rdf:type sh:ValidationResult ;
-				sh:resultSeverity sh:Violation ;
-				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
-				sh:sourceShape _:b639 ;
-				sh:focusNode _:b3 ;
-				sh:resultPath schema:name ;
-				sh:resultMessage "Less than 1 values" ;
-			], [
-				rdf:type sh:ValidationResult ;
-				sh:resultSeverity sh:Violation ;
-				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
-				sh:sourceShape _:b650 ;
-				sh:focusNode _:b1 ;
-				sh:resultPath sh:datatype ;
-				sh:resultMessage "Less than 1 values" ;
-			], [
-				rdf:type sh:ValidationResult ;
-				sh:resultSeverity sh:Violation ;
-				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
-				sh:sourceShape _:b650 ;
-				sh:focusNode _:b3 ;
-				sh:resultPath sh:datatype ;
-				sh:resultMessage "Less than 1 values" ;
-			], [
-				rdf:type sh:ValidationResult ;
-				sh:resultSeverity sh:Violation ;
-				sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
 				sh:sourceShape _:b678 ;
 				sh:focusNode _:b6 ;
 				sh:resultPath rdf:rest ;
@@ -95,9 +63,3 @@ _:b678 sh:path rdf:rest ;
 	sh:maxCount 1 ;
 	sh:minCount 1 ;
 	sh:message "list node needs exactly one rdf:rest" .
-
-_:b639 sh:path schema:name ;
-	sh:minCount 1 .
-
-_:b650 sh:path sh:datatype ;
-	sh:minCount 1 .

--- a/test/standalone-constraint-constraint/warning-qudt-unit.ttl
+++ b/test/standalone-constraint-constraint/warning-qudt-unit.ttl
@@ -52,4 +52,13 @@ PREFIX qudt: <http://qudt.org/schema/qudt/>
             sh:maxCount 1 ;
             qudt:unit unit:KiloGM ;
         ] ;
+    sh:property
+        [
+            sh:datatype xsd:decimal ;
+            sh:path <dimension2> ;
+            schema:name "some Quantity" ;
+            sh:minCount 1 ;
+            sh:maxCount 1 ;
+            qudt:hasUnit unit:KiloGM ;
+        ] ;
 .

--- a/test/standalone-constraint-constraint/warning-qudt-unit.ttl.approved.txt
+++ b/test/standalone-constraint-constraint/warning-qudt-unit.ttl.approved.txt
@@ -8,10 +8,19 @@ _:report a sh:ValidationReport ;
 	sh:result [
 		rdf:type sh:ValidationResult ;
 		sh:resultSeverity sh:Warning ;
-		sh:sourceConstraintComponent sh:NodeConstraintComponent ;
+		sh:sourceConstraintComponent sh:OrConstraintComponent ;
 		sh:sourceShape [
 			sh:path sh:property ;
-			sh:node _:b631 ;
+			sh:or (
+				[
+					sh:path <http://qudt.org/schema/qudt/unit> ;
+					sh:equals <http://qudt.org/schema/qudt/hasUnit> ;
+				]
+				[
+					sh:path <http://qudt.org/schema/qudt/unit> ;
+					sh:maxCount 0 ;
+				]
+			) ;
 			sh:message "The use of qudt:unit is deprecated, please use qudt:hasUnit instead" ;
 			sh:severity sh:Warning ;
 		] ;
@@ -19,18 +28,5 @@ _:report a sh:ValidationReport ;
 		sh:resultPath sh:property ;
 		sh:value _:b3 ;
 		sh:resultMessage "The use of qudt:unit is deprecated, please use qudt:hasUnit instead" ;
-		sh:detail [
-			rdf:type sh:ValidationResult ;
-			sh:resultSeverity sh:Violation ;
-			sh:sourceConstraintComponent sh:EqualsConstraintComponent ;
-			sh:sourceShape _:b631 ;
-			sh:focusNode _:b3 ;
-			sh:resultPath <http://qudt.org/schema/qudt/unit> ;
-			sh:value <http://qudt.org/vocab/unit/KiloGM> ;
-			sh:resultMessage "Must have same values as <http://qudt.org/schema/qudt/hasUnit>" ;
-		] ;
 	] ;
 	sh:conforms false .
-
-_:b631 sh:path <http://qudt.org/schema/qudt/unit> ;
-	sh:equals <http://qudt.org/schema/qudt/hasUnit> .

--- a/validation/standalone-constraint-constraint.ttl
+++ b/validation/standalone-constraint-constraint.ttl
@@ -191,7 +191,7 @@
 
 :restvalue sh:targetObjectsOf rdf:rest ;
     sh:message "rdf:rest value must be a list node or rdf:nil";
-    sh:or ([ sh:node :listnode ] [ sh:hasValue rdf:nil ])
+    sh:xone ([ sh:node :listnode ] [ sh:hasValue rdf:nil ])
 .
 
 :listnode sh:targetSubjectsOf rdf:first, rdf:rest ;

--- a/validation/standalone-constraint-constraint.ttl
+++ b/validation/standalone-constraint-constraint.ttl
@@ -65,10 +65,16 @@
         ] ,
         [
             sh:path sh:property ;
-            sh:node [
-                sh:path qudt:unit ;
-                sh:equals qudt:hasUnit ;
-            ] ;
+            sh:or (
+                      [
+                          sh:path qudt:unit ;
+                          sh:equals qudt:hasUnit ;
+                      ]
+                      [
+                          sh:path qudt:unit ;
+                          sh:maxCount 0 ;
+                      ]
+                  ) ;
             sh:severity sh:Warning ;
             sh:message "The use of qudt:unit is deprecated, please use qudt:hasUnit instead" ;
         ] ;

--- a/validation/standalone-constraint-constraint.ttl
+++ b/validation/standalone-constraint-constraint.ttl
@@ -188,29 +188,20 @@
 
 
 # Testing proper rdf:list construction
-:listnode a sh:NodeShape ;
-    sh:targetClass rdf:List ;
-    sh:property [
-        sh:path rdf:first;
-        sh:minCount 1;
-        sh:maxCount 1;
-    ];
-    sh:property [
-        sh:path rdf:rest;
-        sh:minCount 1;
-        sh:maxCount 1;
-        sh:or (
-            [
-                sh:node :listnode;
-            ]
-            [
-                sh:hasValue rdf:nil;
-            ]
-	    ) ;
-        sh:message "a rdf:List can only have one rdf:rest node, multiples nodes need to be linked"
-        #sh:node :restnode;
-    ]
-    .
+
+:restvalue sh:targetObjectsOf rdf:rest ;
+    sh:message "rdf:rest value must be a list node or rdf:nil";
+    sh:or ([ sh:node :listnode ] [ sh:hasValue rdf:nil ])
+.
+
+:listnode sh:targetSubjectsOf rdf:first, rdf:rest ;
+    sh:property [ sh:path rdf:first ; sh:minCount 1 ; sh:maxCount 1 ;
+        sh:message "list node needs exactly one rdf:first" ] ;
+    sh:property [ sh:path rdf:rest ; sh:minCount 1 ; sh:maxCount 1 ;
+        sh:message "list node needs exactly one rdf:rest" ] ;
+    sh:closed true ;
+    sh:ignoredProperties (rdf:type) .
+
 
 :inversepathnode a sh:NodeShape ;
     sh:property [


### PR DESCRIPTION
for some reason, the current shapes for lists (and also those in shacl-shacl) cause perf issues to the [shacl library](https://github.com/zazuko/rdf-validate-shacl), which fails with big lists (in the order of the thousands elements).

For example, using this constraint:
```bash
$ barnard59 cube fetch-constraint --endpoint https:/int.lindas.admin.ch/query --cube https://energy.ld.admin.ch/elcom/electricityprice > constraint.ttl
```
and trying to validate it:
```bash
barnard59 shacl validate --shapes validation/standalone-constraint-constraint.ttl < constraint.ttl
```
we get the error: Maximum call stack size exceeded.

The error disappears with the shapes proposed in this PR.

I wanted to add an approval test but I gave up because, besides the main meaningful  validation messages, the report includes many confusing result details (the same happens also with the existing list shapes). 

This is a simplified [repro]( https://s.zazuko.com/iDGgdo) with an unexpected focusNode in the result, maybe related to a [known issue](https://github.com/zazuko/rdf-validate-shacl/issues/53)