### PR TITLE
Fix Trifid to work with ESM

### DIFF
--- a/.changeset/swift-socks-call.md
+++ b/.changeset/swift-socks-call.md
@@ -1,0 +1,5 @@
+---
+"cube-link": patch
+---
+
+Fix Trifid instance so that it can work with a CommonJS module

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube-link",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube-link",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch-cache": "^3.1.3",

--- a/trifid/config.json
+++ b/trifid/config.json
@@ -82,7 +82,7 @@
     "vocab-redirect": {
       "priority": 55,
       "module": "trifid-core:./plugins/middleware",
-      "middleware": "cwd:trifid/redirect"
+      "middleware": "cwd:trifid/redirect.cjs"
     }
   }
 }

--- a/trifid/redirect.cjs
+++ b/trifid/redirect.cjs
@@ -7,7 +7,7 @@ const { fetchBuilder, MemoryCache } = require('node-fetch-cache')
  *
  * @returns {import('express').RequestHandler}
  */
-function factory () {
+const factory = () => {
   const cachedFetch = fetchBuilder.withCache(new MemoryCache({
     ttl: 60 * 60 * 1000, // 1 hour
   }))


### PR DESCRIPTION
Fixes #169.

I renamed the redirect custom plugin to `.cjs` and updated the Trifid configuration file.