### PR TITLE
Configure Dependabot for GitHub Actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/  @ludovicm67

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This configures Dependabot for GitHub Actions, in order to make sure they are up-to-date.
The PR also make sure that the PRs from Dependabot gets assigned to me.