### PR TITLE
deduplicate minCount|maxCount Violations

### DIFF
--- a/validation/standalone-constraint-constraint.ttl
+++ b/validation/standalone-constraint-constraint.ttl
@@ -167,14 +167,10 @@
     ];
     sh:property [
         sh:path sh:minCount;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
         sh:hasValue 1 ;
         sh:message "sh:minCount needs to be 1" ;
     ] , [
         sh:path sh:maxCount;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
         sh:hasValue 1 ;
         sh:message "sh:maxCount needs to be 1" ;
     ] ;

--- a/validation/standalone-constraint-constraint.ttl
+++ b/validation/standalone-constraint-constraint.ttl
@@ -168,10 +168,12 @@
     sh:property [
         sh:path sh:minCount;
         sh:hasValue 1 ;
+        sh:maxCount 1 ;
         sh:message "sh:minCount needs to be 1" ;
     ] , [
         sh:path sh:maxCount;
         sh:hasValue 1 ;
+        sh:maxCount 1 ;
         sh:message "sh:maxCount needs to be 1" ;
     ] ;
 .


### PR DESCRIPTION
The current implementation catches Violations twice (once only will do 😄 )

```
Violation: "sh:maxCount needs to be 1" at focus node _:b89_b89_b90_anon2dgenid2d6499f875b0c2499c8204f64b9ba131932d3 with path <http://www.w3.org/ns/shacl#maxCount> (HasValueConstraintComponent of source: _:b89_b781)
Violation: "sh:maxCount needs to be 1" at focus node _:b89_b89_b90_anon2dgenid2d6499f875b0c2499c8204f64b9ba131932d3 with path <http://www.w3.org/ns/shacl#maxCount> (MinCountConstraintComponent of source: _:b89_b781)
```