### PR TITLE
Fix Docker casing, and upgrade to Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/node:20 AS respec
+FROM docker.io/library/node:22 AS respec
 
 # Install some required dependencies to run Puppeteer (for ReSpec)
 RUN apt-get update && apt-get install -y \
@@ -43,7 +43,7 @@ COPY . .
 RUN npm run build
 
 # Final Docker image
-FROM docker.io/library/node:20-alpine
+FROM docker.io/library/node:22-alpine
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/library/node:20 as respec
+FROM docker.io/library/node:20 AS respec
 
-# install some required dependencies to run Puppeteer (for ReSpec)
+# Install some required dependencies to run Puppeteer (for ReSpec)
 RUN apt-get update && apt-get install -y \
   chromium \
   fonts-liberation \
@@ -39,7 +39,7 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm install
 COPY . .
-# start a server locally, and generate the ReSpec HTML file
+# Start a server locally, and generate the ReSpec HTML file
 RUN npm run build
 
 # Final Docker image
@@ -51,7 +51,7 @@ WORKDIR /app
 
 RUN apk add --no-cache tini
 
-# install Trifid
+# Install Trifid
 ENV NODE_ENV=production
 COPY package.json package-lock.json ./
 RUN npm install


### PR DESCRIPTION
This fixes a warning about casing in the Docker file, as the `AS` was not having the same casing as `FROM`.

It also upgrades the NodeJS version used in this image to v22 instead of 20.